### PR TITLE
officeHours.sb Typo

### DIFF
--- a/officeHours.sb
+++ b/officeHours.sb
@@ -21,7 +21,7 @@ Sub frmMain
   GraphicsWindow.CanResize = 0
   GraphicsWindow.Width = 400
   GraphicsWindow.Height = 350
-  GraphicsWindow.Title = "Office Hour"
+  GraphicsWindow.Title = "Office Hours"
   GraphicsWindow.BackgroundColor = GraphicsWindow.GetColorFromRGB(240, 240, 240)
   GraphicsWindow.FontBold = "False"
   GraphicsWindow.BrushColor = "Black"


### PR DESCRIPTION
I corrected the typo in the officeHours Title window to say "Office Hours" instead of "Office Hour".